### PR TITLE
chore: Add `ReadHeaderTimeout`

### DIFF
--- a/internal/core/listeners/http/http.go
+++ b/internal/core/listeners/http/http.go
@@ -47,6 +47,7 @@ func New(s Service, cfg Config) (*Server, error) {
 
 	return &Server{
 		server: &http.Server{
+			ReadHeaderTimeout: 60,
 			Addr: fmt.Sprintf(":%s", cfg.Port),
 			BaseContext: func(net.Listener) context.Context {
 				baseContext := context.Background()


### PR DESCRIPTION
Lint warning in Actions from `gosec` https://github.com/speakeasy-api/rest-template-go/pull/3/files